### PR TITLE
Promise shouldn't be reused

### DIFF
--- a/src/angular-google-plus.js
+++ b/src/angular-google-plus.js
@@ -74,10 +74,10 @@ angular.module('googleplus', []).
     this.$get = ['$q', '$rootScope', '$timeout', function($q, $rootScope, $timeout) {
 
       /**
-       * Create a deferred instance to implement asynchronous calls
+       * Define a deferred instance that will implement asynchronous calls
        * @type {Object}
        */
-      var deferred  = $q.defer();
+      var deferred;
 
       /**
        * NgGooglePlus Class
@@ -86,6 +86,7 @@ angular.module('googleplus', []).
       var NgGooglePlus = function () {};
 
       NgGooglePlus.prototype.login =  function () {
+        deferred  = $q.defer();
         gapi.auth.authorize({
           client_id: options.clientId,
           scope: options.scopes,


### PR DESCRIPTION
With current code, deferred object is created only once and is then reused. This can have multiple issues, especially if you are building single page apps.

For example, I could login with one account, use app for some time, log out from web app and g+, try to login with different user, but defered object would still resolve first login.

I think this issue (#7) will be resolved with this fix as well. 
