### PR TITLE
Added getProfile() method for retrieving Google Plus profile including email address

### DIFF
--- a/src/angular-google-plus.js
+++ b/src/angular-google-plus.js
@@ -144,6 +144,25 @@ angular.module('googleplus', []).
           }
       };
 
+	  NgGooglePlus.prototype.getProfile = function() {
+          var deferred = $q.defer();
+
+	  	  gapi.client.load("oauth2", "v2", function() {
+		    gapi.client.oauth2.userinfo.get().execute(function(resp) {
+		      gapi.client.load("plus", "v1", function() {
+		        gapi.client.plus.people.get({
+		    	  'userId':resp.id
+		    	}).execute(function(profile) {
+		    	  deferred.resolve(profile);
+		    	  $rootScope.$apply();
+		    	});
+		      });
+			});
+		  });
+
+          return deferred.promise;
+      };
+
       NgGooglePlus.prototype.getUser = function() {
           var deferred = $q.defer();
 


### PR DESCRIPTION
I've added a feature that I've got working on my side to 'src'. No testing has been done so I have not included it in 'dist'. The new method should return a profile that includes the user's email address.